### PR TITLE
Fix cleanup for provider listeners

### DIFF
--- a/src/components/Provider.tsx
+++ b/src/components/Provider.tsx
@@ -18,12 +18,23 @@ const ThePoolzProvider = ({ children, overrides }: { children: React.ReactNode, 
       await instance.init()
       setThePoolzInstance(instance)
     }
+
     init().catch(console.error)
-    provider
-      .on("accountsChanged", init)
-      .on("chainChanged", init)
 
+    if (typeof provider?.on === "function") {
+      provider.on("accountsChanged", init)
+      provider.on("chainChanged", init)
+    }
 
+    return () => {
+      if (typeof provider?.removeListener === "function") {
+        provider.removeListener("accountsChanged", init)
+        provider.removeListener("chainChanged", init)
+      } else if (typeof provider?.off === "function") {
+        provider.off("accountsChanged", init)
+        provider.off("chainChanged", init)
+      }
+    }
   }, [provider, setThePoolzInstance]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (


### PR DESCRIPTION
## Summary
- add cleanup listener logic in Provider

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npx jest --runInBand` *(fails: missing ts-node)*

------
https://chatgpt.com/codex/tasks/task_e_685abe10784c83308a6d1d2314b9cfbe